### PR TITLE
Fix comment typos in AWS recognizer

### DIFF
--- a/src/recognizers/aws.ts
+++ b/src/recognizers/aws.ts
@@ -29,10 +29,10 @@ class AWSRecognizer extends CustomEventTarget implements SpeechRecognition {
   /** if the library is currently capturing/transcribing audio */
   public listening = false
 
-  /** the langage (default en-US) */
+  /** the language (default en-US) */
   public lang: Config['lang']
 
-  /** whether to continously transribe audio until .stop() is called */
+  /** whether to continuously transcribe audio until `.stop()` is called */
   public continuous: boolean
 
   /** a proxy for new AWSRecognizer(config) */


### PR DESCRIPTION
## Summary
- correct spelling of `language`
- clarify comment on continuous transcription

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68543662e800832e93dba5c554ed207a