### PR TITLE
Fix event dispatch and MicStream handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import './lib/bufferPolyfill'
 import AWSRecognizer, { configArgs } from './recognizers/aws'
 
-const w = window || {}
+const w = typeof window === 'undefined' ? {} as any : window
 
 const BrowserRecognizer = w.SpeechRecognition || w.webkitSpeechRecognition
 const browserSupportsSpeechRecognition = BrowserRecognizer && new BrowserRecognizer()

--- a/src/lib/MicStream.ts
+++ b/src/lib/MicStream.ts
@@ -24,7 +24,7 @@ class MicStream extends MicrophoneStream {
   }
 
   public static setStream(mediaStream: MediaStream) {
-    if (MicStream.mediaStrem && MicStream.mediaStream.id !== mediaStream.id) {
+    if (MicStream.mediaStream && MicStream.mediaStream.id !== mediaStream.id) {
       MicStream.instance?.stop();
       MicStream.instance = new MicStream(mediaStream);
     }

--- a/src/recognizers/aws.ts
+++ b/src/recognizers/aws.ts
@@ -120,14 +120,14 @@ class AWSRecognizer extends CustomEventTarget implements SpeechRecognition {
 
   /** dispatch events related to sound start */
   private emitSoundStart() {
-    this.dispatchEvent(new ErrorEvent('speechstart'))
-    this.dispatchEvent(new ErrorEvent('soundstart'))
+    this.dispatchEvent(new Event('speechstart'))
+    this.dispatchEvent(new Event('soundstart'))
   }
 
   /** dispatch events realated to sound end */
   private emitSoundEnd() {
-    this.dispatchEvent(new ErrorEvent('speechend'))
-    this.dispatchEvent(new ErrorEvent('soundend'))
+    this.dispatchEvent(new Event('speechend'))
+    this.dispatchEvent(new Event('soundend'))
   }
 
   /** authenticate and connect to AWS Transcribe */


### PR DESCRIPTION
## Summary
- fix `MicStream` typo so new streams are detected
- dispatch `speechstart`, `soundstart`, `speechend`, and `soundend` using `Event`
- guard against missing `window` object in entrypoint

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854357e5ae0832ea1b5e7b809c07a61