### PR TITLE
Resolve open issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ recognition.onresult = function(event) {
 recognition.onerror = console.error
 ```
 
+## Demo
+
+Check the [examples](./examples) folder for a simple HTML page that shows how to
+use the polyfill. Replace the placeholder AWS credentials with your own before
+running the example.
+
 ## Roadmap
 
 * Further increase parity between the two implementations by better supporting additional options and events.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Demo
+
+Open `index.html` in a browser and replace the `IdentityPoolId` and `region` with your AWS credentials to try the polyfill.

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Speech Recognition AWS Polyfill Demo</title>
+</head>
+<body>
+  <button id="startBtn">Start</button>
+  <p id="output"></p>
+  <script src="https://unpkg.com/speech-recognition-aws-polyfill"></script>
+  <script>
+    const recognition = new window.SpeechRecognitionPolyfill({
+      IdentityPoolId: 'YOUR_IDENTITY_POOL_ID',
+      region: 'YOUR_REGION'
+    });
+    recognition.onresult = evt => {
+      document.getElementById('output').textContent = evt.results[0][0].transcript;
+    };
+    recognition.onerror = console.error;
+
+    document.getElementById('startBtn').addEventListener('click', () => {
+      recognition.start();
+    });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "description": "Polyfill for the SpeechRecognition browser API using AWS Transcribe",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "jest",
     "build": "webpack",

--- a/src/lib/bufferPolyfill.ts
+++ b/src/lib/bufferPolyfill.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer'
 
-// @ts-ignore
-if (window && typeof window.Buffer === 'undefined') {
-  // @ts-ignore
-  window.Buffer = Buffer
+// ensure the Buffer polyfill only runs in browsers
+if (typeof window !== 'undefined' && typeof (window as any).Buffer === 'undefined') {
+  // @ts-ignore - window is defined in browsers
+  (window as any).Buffer = Buffer
 }

--- a/src/recognizers/aws.ts
+++ b/src/recognizers/aws.ts
@@ -231,7 +231,7 @@ class AWSRecognizer extends CustomEventTarget implements SpeechRecognition {
       connection.onmessage = createPipe(
         prop('data'),
         Buffer.from,
-        (buffer: Buffer) => eventStreamMarshaller.unmarshall(buffer) as MessageEvent,
+        (buffer: Buffer) => eventStreamMarshaller.unmarshall(buffer),
         ifElse(
           pathEq(['headers', ':message-type', 'value'], 'event'),
           // valid response

--- a/src/recognizers/aws.ts
+++ b/src/recognizers/aws.ts
@@ -72,7 +72,7 @@ class AWSRecognizer extends CustomEventTarget implements SpeechRecognition {
   /** stop capturing and return any final transcriptions */
   public stop() {
     MicStream.getInstance()?.end()
-    Connection.getInstance()?.close()
+    Connection.close()
     this.listening = false
     this.dispatchEvent(new Event('audioend'))
   }
@@ -81,7 +81,7 @@ class AWSRecognizer extends CustomEventTarget implements SpeechRecognition {
   public abort() {
     if (this.listening) {
       MicStream.getInstance()?.end()
-      Connection.getInstance()?.close()
+      Connection.close()
       this.listening = false
       this.dispatchEvent(new Event('audioend'))
     }
@@ -248,7 +248,13 @@ class AWSRecognizer extends CustomEventTarget implements SpeechRecognition {
               // emit the transcription result
               createPipe(
                 pathOr('', [0, 'Alternatives', 0, 'Transcript']),
-                decodeURIComponent,
+                (t: string) => {
+                  try {
+                    return decodeURIComponent(t)
+                  } catch {
+                    return t
+                  }
+                },
                 this.emitResult.bind(this)
               )
             )

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,0 +1,6 @@
+import SpeechRecognitionPolyfill from '../src'
+
+test('polyfill is defined', () => {
+  // TODO: implement an automated e2e test for microphone input
+  expect(SpeechRecognitionPolyfill).toBeDefined()
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
     "strictPropertyInitialization": false,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
   },
   "include": [
     "src",


### PR DESCRIPTION
## Summary
- include `dist` folder in package and expose types
- avoid window reference errors in buffer polyfill
- safely decode transcripts in AWS recognizer
- close WebSocket properly when stopping
- add example demo folder
- sketch an e2e test
- document demo example
- fix e2e test unused variable error

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6854395c0f84832ea0ab41380cef3f6c